### PR TITLE
feat: 支持小程序插件功能页的构建

### DIFF
--- a/packages/webpack-plugin/src/ExternalDependency.js
+++ b/packages/webpack-plugin/src/ExternalDependency.js
@@ -8,7 +8,7 @@ class ExternalDependency extends ModuleDependency {
   }
 
   get type() {
-    return 'external entey'
+    return 'external entry'
   }
 }
 

--- a/packages/webpack-plugin/src/loaders/app-json-loader.js
+++ b/packages/webpack-plugin/src/loaders/app-json-loader.js
@@ -1,4 +1,5 @@
 import { getOptions } from 'loader-utils'
+import fs from 'fs'
 import path from 'path'
 import {
   addDependency,
@@ -222,6 +223,23 @@ export default asyncLoaderWrapper(async function (source) {
 
     moduleContent.themeLocation = 'theme.json'
   }
+
+    // 小程序插件宿主小程序，主要是支付功能页和用户信息功能页（用户信息功能页只需要配置无需代码）
+    if (moduleContent.functionalPages) {
+      const fileName = 'functional-pages/request-payment'
+      if (!fs.existsSync(`${appContext}/${fileName}.js`)) return '//'
+
+      const resolvedMainRequest = await resolveWithType(this, 'miniprogram/javascript', fileName)
+      await addExternal(
+        this,
+        stringifyResource(resolvedMainRequest, getMpflowLoaders(this, resolvedMainRequest, 'javascript'), {
+          disabled: 'normal',
+        }),
+        'main',
+        fileName,
+        fileName,
+      )
+    }
 
   return '//'
 })


### PR DESCRIPTION
1、依照微信小程序的规定，app.json 中配置了 functionalPages 才能生效插件功能页。因此从解析 app.json 开始下手。
2、由于只有支付功能页需要独立的一个固定名称位置（functional-pages/request-payment.js）的文件，因此特殊处理。